### PR TITLE
Drop legacy configuration

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,0 @@
----
-.travis.yml:
-  test_with_debian_puppet:
-    stretch: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ language: "ruby"
 script: "bundle exec rake rubocop validate lint spec"
 matrix:
   include:
-  - name: "Debian Stretch"
-    rvm: "2.3.3"
-    env: PUPPET_VERSION='4.8.2'
   - name: "Puppet 5"
     rvm: "2.4.5"
     env: PUPPET_VERSION='~> 5.0'


### PR DESCRIPTION
We do not need to test against unsupported Puppet versions anymore.